### PR TITLE
Close the protobuf session on shutdown

### DIFF
--- a/flipper_api.py
+++ b/flipper_api.py
@@ -143,5 +143,9 @@ class FlipperAPI():
         with self.mutex:
             self._cmd_storage_write(path, data)
 
+    def close(self):
+        with self.mutex:
+            self.proto.cmd_flipper_stop_session()
+
 class InvalidNameError(RuntimeError):
     pass

--- a/flipper_fs.py
+++ b/flipper_fs.py
@@ -189,3 +189,6 @@ class FlipperZeroFileSystem(fuse.Operations, fuse.LoggingMixIn):
         cached = self.get_file_by_path(path)
         self.api.delete(path, True)
         cached['parent']['children'].remove(cached)
+
+    def close(self):
+        self.api.close()

--- a/fzfs.py
+++ b/fzfs.py
@@ -55,6 +55,7 @@ def main():
     fuse.FUSE(backend, args.mountpoint, foreground=True)
     print('fuse stopped')
 
+    backend.close()
     flsrl.close()
 
 if __name__ == '__main__':


### PR DESCRIPTION
The key benefit of this is that after ctrl+c'ing fzfs, you can use the serial port again as a CLI without unplugging and plugging back in the flipper zero. This makes developing CLI applications a lot easier :) 